### PR TITLE
chore: :busts_in_silhouette: add signekb to contributors

### DIFF
--- a/_contributors.qmd
+++ b/_contributors.qmd
@@ -1,4 +1,4 @@
 These are the people who have contributed by submitting changes through pull requests :tada:
 
 
- [\@lwjohnst86](https://github.com/lwjohnst86)
+ [\@lwjohnst86](https://github.com/lwjohnst86), [\@signekb](https://github.com/signekb)


### PR DESCRIPTION
# Description

I was added when I ran `just run-all`.
