### PR TITLE
refactor: :memo: explain how releases work in CHANGELOG

### DIFF
--- a/template/CHANGELOG.md
+++ b/template/CHANGELOG.md
@@ -3,20 +3,19 @@
 Since we follow [Conventional
 Commits](https://decisions.seedcase-project.org/why-conventional-commits)
 when writing commit messages, we're able to automatically create formal
-"releases" of the workshop based on what the commit message says.
-Releases in the context of workshops are simply snapshots in time of the
-workshop content that we publish automatically to Zenodo for easier
-discovery, archival, and citation purposes. We use
+"releases" of the workshop based on the commit messages. Releases in the
+context of workshops are simply snapshots in time of the workshop
+content that we publish to Zenodo for easier discovery, archival, and
+citation purposes. We use
 [Commitizen](https://decisions.seedcase-project.org/why-semantic-release-with-commitizen)
 to be able to automatically create these releases, which uses
-[SemVar](https://semverdoc.org) as the version numbering scheme (`0.0.0`
-means `MAJOR.MINOR.PATCH`).
+[SemVar](https://semverdoc.org) as the version numbering scheme.
 
-Because a new release can be created based on the commit message,
-releases can happen quite often, sometimes several in a day. It also
-means any individual release will not have many changes within it. Below
-is a list of the releases we've made so far, along with what was changed
-within it.
+Because a new release is created based on the commit message, releases
+can happen quite often, sometimes several in a day. It also means any
+individual release will not have many changes within it. Below is a list
+of the releases we've made so far, along with what was changed within
+it.
 
 If you attended a workshop or used the workshop material as some point
 in time, you can always refer to this changelog page to find out what

--- a/template/CHANGELOG.md
+++ b/template/CHANGELOG.md
@@ -5,16 +5,14 @@ Commits](https://decisions.seedcase-project.org/why-conventional-commits)
 when writing commit messages, we're able to automatically create formal
 "releases" of the workshop based on the commit messages. Releases in the
 context of workshops are simply snapshots in time of the workshop
-content. The releases are published to Zenodo for easier discovery, archival, and
-citation purposes. We use
+content. The releases are published to Zenodo for easier discovery,
+archival, and citation purposes. We use
 [Commitizen](https://decisions.seedcase-project.org/why-semantic-release-with-commitizen)
 to be able to automatically create these releases, which uses
 [SemVar](https://semverdoc.org) as the version numbering scheme.
 
-Because releases are created based on commit messages, we release
-
-quite often, sometimes several times in a day. This also means that any
-
+Because releases are created based on commit messages, we release quite
+often, sometimes several times in a day. This also means that any
 individual release will not have many changes within it. Below is a list
 of the releases we've made so far, along with what was changed within
 each release.

--- a/template/CHANGELOG.md
+++ b/template/CHANGELOG.md
@@ -5,17 +5,19 @@ Commits](https://decisions.seedcase-project.org/why-conventional-commits)
 when writing commit messages, we're able to automatically create formal
 "releases" of the workshop based on the commit messages. Releases in the
 context of workshops are simply snapshots in time of the workshop
-content that we publish to Zenodo for easier discovery, archival, and
+content. The releases are published to Zenodo for easier discovery, archival, and
 citation purposes. We use
 [Commitizen](https://decisions.seedcase-project.org/why-semantic-release-with-commitizen)
 to be able to automatically create these releases, which uses
 [SemVar](https://semverdoc.org) as the version numbering scheme.
 
-Because a new release is created based on the commit message, releases
-can happen quite often, sometimes several in a day. It also means any
+Because releases are created based on commit messages, we release
+
+quite often, sometimes several times in a day. This also means that any
+
 individual release will not have many changes within it. Below is a list
 of the releases we've made so far, along with what was changed within
-it.
+each release.
 
 If you attended a workshop or used the workshop material as some point
 in time, you can always refer to this changelog page to find out what

--- a/template/CHANGELOG.md
+++ b/template/CHANGELOG.md
@@ -1,11 +1,23 @@
 # Changelog
 
 Since we follow [Conventional
-Commits](https://decisions.seedcase-project.org/why-conventional-commits),
-we're able to automatically create a release based on the commit message
-by using
-[Commitizen](https://decisions.seedcase-project.org/why-semantic-release-with-commitizen).
-This means that releases can happen quite often, sometimes several in
-a day. It also means any individual release will not have many changes
-within it. Below is a list of releases along with what was changed
+Commits](https://decisions.seedcase-project.org/why-conventional-commits)
+when writing commit messages, we're able to automatically create formal
+"releases" of the workshop based on what the commit message says.
+Releases in the context of workshops are simply snapshots in time of the
+workshop content that we publish automatically to Zenodo for easier
+discovery, archival, and citation purposes. We use
+[Commitizen](https://decisions.seedcase-project.org/why-semantic-release-with-commitizen)
+to be able to automatically create these releases, which uses
+[SemVar](https://semverdoc.org) as the version numbering scheme (`0.0.0`
+means `MAJOR.MINOR.PATCH`).
+
+Because a new release can be created based on the commit message,
+releases can happen quite often, sometimes several in a day. It also
+means any individual release will not have many changes within it. Below
+is a list of the releases we've made so far, along with what was changed
 within it.
+
+If you attended a workshop or used the workshop material as some point
+in time, you can always refer to this changelog page to find out what
+has been changed since you last used it.


### PR DESCRIPTION
# Description

I realized that the text was originally mainly targeted to software projects, so I expanded on the explanation of releases in workshop setting.

## Checklist

- [x] Formatted Markdown
- [x] Ran `just run-all`
